### PR TITLE
Add configs to control how ratios are displayed

### DIFF
--- a/src/main/java/io/github/debuggyteam/tablesaw/client/ClientSettings.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/ClientSettings.java
@@ -1,0 +1,21 @@
+package io.github.debuggyteam.tablesaw.client;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.WrappedConfig;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.Processor;
+
+@Processor("setSerializer")
+public class ClientSettings extends WrappedConfig {
+	@Comment("How to display ratios on recipe icons in the TableSaw interface.")
+	public final RatioDisplay iconRatios = RatioDisplay.OUTPUT_COUNT;
+	
+	@Comment("If true, overrides the name in recipe tooltips to show the input -> output ratio.")
+	public final Boolean ratioTooltip = true;
+	
+	public ClientSettings() {}
+	
+	public void setSerializer(Config.Builder builder) {
+		builder.format("json5");
+	}
+}

--- a/src/main/java/io/github/debuggyteam/tablesaw/client/RatioDisplay.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/RatioDisplay.java
@@ -1,22 +1,9 @@
 package io.github.debuggyteam.tablesaw.client;
 
-import net.minecraft.text.Text;
-import net.minecraft.util.Nameable;
-
-public enum RatioDisplay implements Nameable {
-	NONE("none"),
-	RATIO("ratio"),
-	OUTPUT_COUNT("output_count")
+public enum RatioDisplay {
+	NONE,
+	RATIO,
+	STRICT_RATIO,
+	OUTPUT_COUNT
 	;
-	
-	private final String name;
-	
-	RatioDisplay(String name) {
-		this.name = name;
-	}
-	
-	@Override
-	public Text getName() {
-		return Text.literal(name);
-	}
 }

--- a/src/main/java/io/github/debuggyteam/tablesaw/client/RatioDisplay.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/RatioDisplay.java
@@ -1,0 +1,22 @@
+package io.github.debuggyteam.tablesaw.client;
+
+import net.minecraft.text.Text;
+import net.minecraft.util.Nameable;
+
+public enum RatioDisplay implements Nameable {
+	NONE("none"),
+	RATIO("ratio"),
+	OUTPUT_COUNT("output_count")
+	;
+	
+	private final String name;
+	
+	RatioDisplay(String name) {
+		this.name = name;
+	}
+	
+	@Override
+	public Text getName() {
+		return Text.literal(name);
+	}
+}

--- a/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawClient.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawClient.java
@@ -4,7 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.render.RenderLayer;
+
+import org.quiltmc.config.api.WrappedConfig;
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.config.QuiltConfig;
 import org.quiltmc.qsl.base.api.entrypoint.client.ClientModInitializer;
 import org.quiltmc.qsl.block.extensions.api.client.BlockRenderLayerMap;
 import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
@@ -25,9 +28,15 @@ import net.minecraft.util.registry.Registry;
 import static io.github.debuggyteam.tablesaw.TableSaw.TABLESAW;
 
 public class TableSawClient implements ClientModInitializer {
-
+	
+	public static ClientSettings config;
+	
 	@Override
 	public void onInitializeClient(ModContainer mod) {
+		
+		config = QuiltConfig.create(TableSaw.MODID, "client", ClientSettings.class);
+		
+		
 		HandledScreens.register(TableSaw.TABLESAW_SCREEN_HANDLER, (TableSawScreenHandler gui, PlayerInventory inventory, Text title) -> new TableSawScreen(gui, inventory, title));
 		
 		ClientPlayNetworking.registerGlobalReceiver(TableSaw.TABLESAW_CHANNEL, (client, handler, buf, sender) -> {

--- a/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawScreen.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawScreen.java
@@ -21,6 +21,7 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -235,10 +236,12 @@ public class TableSawScreen extends HandledScreen<TableSawScreenHandler> {
 				ItemStack stack = list.get(curSlot).getResult();
 				this.client.getItemRenderer().renderInGuiWithOverrides(stack, x + (xi * RECIPE_SLOT_WIDTH), y + (yi * RECIPE_SLOT_HEIGHT) + 2);
 				
-				String label = null;
-				if (recipe.getQuantity() != 1) {
-					label = recipe.getQuantity() + ":" + stack.getCount();
-				}
+				String label = switch( TableSawClient.config.iconRatios ) {
+					case NONE -> null;
+					case RATIO -> (recipe.getQuantity() < 1) ? null : recipe.getQuantity() + ":" + stack.getCount();
+					case OUTPUT_COUNT -> (recipe.getResult().getCount() < 2) ? null : Integer.toString(recipe.getResult().getCount());
+				};
+				
 				
 				this.itemRenderer.renderGuiItemOverlay(this.textRenderer, stack, x + (xi * RECIPE_SLOT_WIDTH), y + (yi * RECIPE_SLOT_HEIGHT) + 2, label);
 				
@@ -264,7 +267,25 @@ public class TableSawScreen extends HandledScreen<TableSawScreenHandler> {
 					int hoveredSlot = (scrollOffset * 4) + (gridY * 4) + gridX;
 					List<TableSawRecipe> list = this.getClientsideRecipes();
 					if (hoveredSlot >= 0 && hoveredSlot < list.size()) {
-						renderTooltip(matrices, list.get(hoveredSlot).getResult(), x, y);
+						
+						if (TableSawClient.config.ratioTooltip) {
+							ItemStack input = this.handler.input.getStack(0);
+							ItemStack output = list.get(hoveredSlot).getResult();
+							
+							List<Text> text = this.getTooltipFromItem(output);
+							
+							int sourceCount = list.get(hoveredSlot).getQuantity();
+							Text sourceName = Text.empty().append(input.getName()).formatted(input.getRarity().formatting);
+							Text destName = Text.empty().append(output.getName()).formatted(output.getRarity().formatting);
+							
+							MutableText recipeLine = Text.translatable("container.tablesaw.tablesaw.ratio", sourceCount, sourceName, output.getCount(), destName);
+							text.set(0, Text.empty().append(recipeLine));
+							
+							renderTooltip(matrices, text, x, y);
+						} else {
+							renderTooltip(matrices, list.get(hoveredSlot).getResult(), x, y);
+						}
+						
 					}
 				}
 			}

--- a/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawScreen.java
+++ b/src/main/java/io/github/debuggyteam/tablesaw/client/TableSawScreen.java
@@ -237,9 +237,10 @@ public class TableSawScreen extends HandledScreen<TableSawScreenHandler> {
 				this.client.getItemRenderer().renderInGuiWithOverrides(stack, x + (xi * RECIPE_SLOT_WIDTH), y + (yi * RECIPE_SLOT_HEIGHT) + 2);
 				
 				String label = switch( TableSawClient.config.iconRatios ) {
-					case NONE -> null;
-					case RATIO -> (recipe.getQuantity() < 1) ? null : recipe.getQuantity() + ":" + stack.getCount();
-					case OUTPUT_COUNT -> (recipe.getResult().getCount() < 2) ? null : Integer.toString(recipe.getResult().getCount());
+					case NONE -> "";
+					case RATIO -> (recipe.getQuantity() < 2) ? null : recipe.getQuantity() + ":" + stack.getCount();
+					case STRICT_RATIO -> recipe.getQuantity() + ":" + stack.getCount();
+					case OUTPUT_COUNT -> null; //(recipe.getResult().getCount() < 2) ? null : Integer.toString(recipe.getResult().getCount());
 				};
 				
 				

--- a/src/main/resources/assets/tablesaw/lang/en_us.json
+++ b/src/main/resources/assets/tablesaw/lang/en_us.json
@@ -1,4 +1,5 @@
 {
   "container.tablesaw.tablesaw": "Table Saw",
+  "container.tablesaw.tablesaw.ratio": "%s %s → %s %s",
   "block.tablesaw.tablesaw": "Table Saw"
 }


### PR DESCRIPTION
Addresses user feedback concerning the readability of recipe input/output counts at some zoom levels.

* Uses quilt-config to load in json5 settings
* Adds configurable icon and tooltip display
* Changes default behavior to show the output count on icon, and the ratio in the tooltip